### PR TITLE
fix: read nullable values correctly

### DIFF
--- a/src/main/java/com/cognite/sa/beam/bq/CdfLabelsBQ.java
+++ b/src/main/java/com/cognite/sa/beam/bq/CdfLabelsBQ.java
@@ -142,7 +142,7 @@ public class CdfLabelsBQ {
                     return new TableRow()
                             .set("external_id", element.getExternalId())
                             .set("name", element.getName())
-                            .set("description", element.hasDescription() ? element.getDescription() : null)
+                            .set("description", element.hasDescription() ? element.getDescription().getValue() : null)
                             .set("created_time", element.hasCreatedTime()
                                     ? formatter.format(Instant.ofEpochMilli(element.getCreatedTime().getValue())) : null)
                             .set("row_updated_time", formatter.format(Instant.now()));


### PR DESCRIPTION
Replications with `null` descriptions where failing. This fixes the issue.