### PR TITLE
 Update attributes in BQ replication

### DIFF
--- a/src/main/java/com/cognite/sa/beam/bq/CdfFilesBQ.java
+++ b/src/main/java/com/cognite/sa/beam/bq/CdfFilesBQ.java
@@ -67,6 +67,7 @@ public class CdfFilesBQ {
             new TableFieldSchema().setName("source").setType("STRING"),
             new TableFieldSchema().setName("asset_ids").setType("INT64").setMode("REPEATED"),
             new TableFieldSchema().setName("security_categories").setType("INT64").setMode("REPEATED"),
+            new TableFieldSchema().setName("labels").setType("STRING").setMode("REPEATED"),
             new TableFieldSchema().setName("uploaded").setType("BOOL"),
             new TableFieldSchema().setName("uploaded_time").setType("TIMESTAMP"),
             new TableFieldSchema().setName("created_time").setType("TIMESTAMP"),
@@ -172,6 +173,7 @@ public class CdfFilesBQ {
                 .withFormatFunction((FileMetadata element) -> {
                     List<Long> assetIds = element.getAssetIdsList();
                     List<Long> securityCategories = element.getSecurityCategoriesList();
+                    List<String> labels = element.getLabelsList();
                     List<TableRow> metadata = new ArrayList<>();
                     DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
 
@@ -194,6 +196,7 @@ public class CdfFilesBQ {
                             .set("source", element.hasSource() ? element.getSource() : null)
                             .set("asset_ids", assetIds)
                             .set("security_categories", securityCategories)
+                            .set("labels", labels)
                             .set("uploaded", element.getUploaded())
                             .set("uploaded_time", element.hasUploadedTime() ?
                                     formatter.format(Instant.ofEpochMilli(element.getUploadedTime())) : null)

--- a/src/main/java/com/cognite/sa/beam/bq/CdfFilesBQ.java
+++ b/src/main/java/com/cognite/sa/beam/bq/CdfFilesBQ.java
@@ -62,6 +62,7 @@ public class CdfFilesBQ {
             new TableFieldSchema().setName("source_created_time").setType("TIMESTAMP"),
             new TableFieldSchema().setName("source_modified_time").setType("TIMESTAMP"),
             new TableFieldSchema().setName("name").setType("STRING"),
+            new TableFieldSchema().setName("directory").setType("STRING"),
             new TableFieldSchema().setName("mime_type").setType("STRING"),
             new TableFieldSchema().setName("source").setType("STRING"),
             new TableFieldSchema().setName("asset_ids").setType("INT64").setMode("REPEATED"),
@@ -188,6 +189,7 @@ public class CdfFilesBQ {
                             .set("source_modified_time", element.hasSourceModifiedTime() ?
                                     formatter.format(Instant.ofEpochMilli(element.getSourceModifiedTime())) : null)
                             .set("name", element.hasName() ? element.getName() : null)
+                            .set("directory", element.hasDirectory() ? element.getDirectory() : null)
                             .set("mime_type", element.hasMimeType() ? element.getMimeType() : null)
                             .set("source", element.hasSource() ? element.getSource() : null)
                             .set("asset_ids", assetIds)

--- a/src/main/java/com/cognite/sa/beam/bq/CdfLabelsBQ.java
+++ b/src/main/java/com/cognite/sa/beam/bq/CdfLabelsBQ.java
@@ -55,6 +55,7 @@ public class CdfLabelsBQ {
             new TableFieldSchema().setName("external_id").setType("STRING"),
             new TableFieldSchema().setName("name").setType("STRING"),
             new TableFieldSchema().setName("description").setType("STRING"),
+            new TableFieldSchema().setName("data_set_id").setType("INT64"),
             new TableFieldSchema().setName("created_time").setType("TIMESTAMP"),
             new TableFieldSchema().setName("row_updated_time").setType("TIMESTAMP")
     ));
@@ -140,6 +141,7 @@ public class CdfLabelsBQ {
                             .set("external_id", element.getExternalId())
                             .set("name", element.getName())
                             .set("description", element.hasDescription() ? element.getDescription() : null)
+                            .set("data_set_id", element.hasDataSetId() ? element.getDataSetId() : null)
                             .set("created_time", element.hasCreatedTime()
                                     ? formatter.format(Instant.ofEpochMilli(element.getCreatedTime())) : null)
                             .set("row_updated_time", formatter.format(Instant.now()));


### PR DESCRIPTION
Additions:
- `directory` field for CDF Files
- `labels` field for CDF Files
- `data_set_id` for CDF Labels